### PR TITLE
Add node's chain status to host.Connect()

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -84,7 +84,7 @@ func connect(ctx *cli.Context) error {
 		return errors.Wrap(err, "unable to parse ENR")
 	}
 
-	details, err := host.Connect(enr.GetHostInfo())
+	details, chain, err := host.Connect(enr.GetHostInfo())
 	if err != nil {
 		logrus.Info("Couldn't connect to Node: ", enr.ID, ": ", err)
 		return nil
@@ -97,8 +97,15 @@ func connect(ctx *cli.Context) error {
 	logrus.Info("Node's ID: ", enr.ID.String())
 	logrus.Info("Node's Pubkey: ", enr.Pubkey)
 	logrus.Info("Node's Seq: ", enr.Seq)
+	// node info
 	logrus.Info("Node's Client: ", details.ClientName)
 	logrus.Info("Node's Capabilities: ", details.Capabilities)
 	logrus.Info("Node's SoftwareInfo: ", details.SoftwareInfo)
+	// chain details
+	logrus.Info("Node's NetworkID: ", chain.NetworkID)
+	logrus.Info("Node's ForkID: ", chain.ForkID)
+	logrus.Info("Node's ProtocolVersion: ", chain.ProtocolVersion)
+	logrus.Info("Node's HeadHash: ", chain.HeadHash)
+	logrus.Info("Node's TotalDiff: ", chain.TotalDifficulty)
 	return nil
 }

--- a/crawler/peering.go
+++ b/crawler/peering.go
@@ -170,7 +170,7 @@ func (p *Peering) connect(hInfo models.HostInfo) (models.ConnectionAttempt, mode
 	connAttempt := models.NewConnectionAttempt(nodeID)
 	nInfo, _ := models.NewNodeInfo(nodeID, models.WithHostInfo(hInfo))
 
-	handshakeDetails, err := p.host.Connect(&hInfo)
+	handshakeDetails, chainDetails, err := p.host.Connect(&hInfo)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{
 			"node-id": nodeID.String(),
@@ -180,9 +180,14 @@ func (p *Peering) connect(hInfo models.HostInfo) (models.ConnectionAttempt, mode
 		connAttempt.Status = models.FailedConnection
 	} else {
 		logrus.WithFields(logrus.Fields{
-			"node-id":      nodeID.String(),
-			"client":       handshakeDetails.ClientName,
-			"capabilities": handshakeDetails.Capabilities,
+			"node-id":          nodeID.String(),
+			"client":           handshakeDetails.ClientName,
+			"capabilities":     handshakeDetails.Capabilities,
+			"network":          chainDetails.NetworkID,
+			"fork-id":          chainDetails.ForkID.Hash,
+			"head-hash":        chainDetails.HeadHash.String(),
+			"protocol-version": chainDetails.ProtocolVersion,
+			"total-diff":       chainDetails.TotalDifficulty,
 		}).Info("successfull connection")
 		connAttempt.Error = ethtest.ErrorNone
 		connAttempt.Status = models.SuccessfulConnection

--- a/crawler/peering.go
+++ b/crawler/peering.go
@@ -93,7 +93,7 @@ func (p *Peering) runOrcherster() {
 	startT := time.NewTicker(InitDelay)
 	// update the nodes from the db
 	updateNodes := func() {
-		newNodeSet, err := p.db.GetNonDeprecatedNodes()
+		newNodeSet, err := p.db.GetNonDeprecatedNodes(p.host.localChainStatus.NetworkID)
 		if err != nil {
 			logEntry.Panic("unable to update local set of nodes from DB")
 		}
@@ -190,6 +190,7 @@ func (p *Peering) connect(hInfo models.HostInfo) (models.ConnectionAttempt, mode
 			"total-diff":       chainDetails.TotalDifficulty,
 		}).Info("successfull connection")
 		connAttempt.Error = ethtest.ErrorNone
+		connAttempt.Status = models.SuccessfulConnection
 		nInfo.HandshakeDetails = handshakeDetails
 		nInfo.ChainDetails = chainDetails
 	}

--- a/db/batch.go
+++ b/db/batch.go
@@ -100,19 +100,18 @@ func (q *QueryBatch) persistBatch() error {
 	}
 	// check if there was any error
 	if qerr != nil {
-		log.WithFields(log.Fields{
-			"error":  qerr.Error(),
-			"query":  q.persistables[cnt-1].query,
-			"values": q.persistables[cnt-1].values,
-		}).Errorf("unable to persist query [%d]", cnt-1)
 		return errors.Wrap(qerr, "error persisting batch")
 	}
+	/*
+		// debug the queries (redice batch size and enable this)
+		for idx, item := range q.persistables {
+			fmt.Println("-> q:  ", idx)
+			fmt.Println("query: ", item.query)
+			fmt.Println("values:", item.values)
+		}
+		log.Panicf("panic on query")
+	*/
 	if ctx.Err() == context.DeadlineExceeded {
-		log.WithFields(log.Fields{
-			"error":  ctx.Err().Error(),
-			"query":  q.persistables[cnt-1].query,
-			"values": q.persistables[cnt-1].values,
-		}).Errorf("timed-out [query %d]", cnt-1)
 		return errors.Wrap(ctx.Err(), "error persisting batch")
 	}
 	return nil

--- a/db/migrations/000003_add_chain_details_to_node_info.down.sql
+++ b/db/migrations/000003_add_chain_details_to_node_info.down.sql
@@ -1,0 +1,6 @@
+-- Roll back node's chain details from node_info
+ALTER TABLE node_info DROP COLUMN IF EXISTS fork_id;
+ALTER TABLE node_info DROP COLUMN IF EXISTS protocol_version;
+ALTER TABLE node_info DROP COLUMN IF EXISTS head_hash;
+ALTER TABLE node_info DROP COLUMN IF EXISTS network_id;
+ALTER TABLE node_info DROP COLUMN IF EXISTS total_difficulty;

--- a/db/migrations/000003_add_chain_details_to_node_info.up.sql
+++ b/db/migrations/000003_add_chain_details_to_node_info.up.sql
@@ -2,5 +2,5 @@
 ALTER TABLE node_info ADD COLUMN fork_id TEXT;
 ALTER TABLE node_info ADD COLUMN protocol_version INT;
 ALTER TABLE node_info ADD COLUMN head_hash TEXT;
-ALTER TABLE node_info ADD COLUMN network_id INT;
-ALTER TABLE node_info ADD COLUMN total_difficulty BIGINT;
+ALTER TABLE node_info ADD COLUMN network_id NUMERIC(1000, 0);
+ALTER TABLE node_info ADD COLUMN total_difficulty NUMERIC(1000, 0);

--- a/db/migrations/000003_add_chain_details_to_node_info.up.sql
+++ b/db/migrations/000003_add_chain_details_to_node_info.up.sql
@@ -1,0 +1,6 @@
+-- Add new columns on node_info about node's chain details
+ALTER TABLE node_info ADD COLUMN fork_id TEXT;
+ALTER TABLE node_info ADD COLUMN protocol_version INT;
+ALTER TABLE node_info ADD COLUMN head_hash TEXT;
+ALTER TABLE node_info ADD COLUMN network_id INT;
+ALTER TABLE node_info ADD COLUMN total_difficulty BIGINT;

--- a/db/node.go
+++ b/db/node.go
@@ -25,7 +25,7 @@ func (d *PostgresDBService) insertConnectionAttempt(attempt models.ConnectionAtt
 	return query, args
 }
 
-func (d *PostgresDBService) upsertNodeInfo(nInfo models.NodeInfo) (query string, args []interface{}) {
+func (d *PostgresDBService) upsertNodeInfo(nInfo models.NodeInfo, sameNetwork bool) (query string, args []interface{}) {
 	query = `
 	INSERT INTO node_info(
 		node_id,
@@ -42,9 +42,14 @@ func (d *PostgresDBService) upsertNodeInfo(nInfo models.NodeInfo) (query string,
 		client_arch,
 		client_language,
 		capabilities,
-		software_info,        
+		software_info,
+	    fork_id,
+		protocol_version,
+		head_hash,
+		network_id,
+		total_difficulty,
 		deprecated
-	) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+	) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
 	ON CONFLICT (node_id) DO UPDATE SET
 		ip = $3,
 		tcp = $4,
@@ -61,7 +66,12 @@ func (d *PostgresDBService) upsertNodeInfo(nInfo models.NodeInfo) (query string,
 		client_language = $13,
 		capabilities = $14,
 		software_info = $15,
-		deprecated = $16;
+	    fork_id = $16,
+		protocol_version = $17,
+		head_hash = $18,
+		network_id = $19,
+		total_difficulty = $20,
+		deprecated = $21;
 	`
 	clientDetails := models.ParseUserAgent(nInfo.ClientName)
 	capabilities := make([]string, len(nInfo.Capabilities))
@@ -77,6 +87,7 @@ func (d *PostgresDBService) upsertNodeInfo(nInfo models.NodeInfo) (query string,
 	args = append(args, nInfo.TCP)
 	args = append(args, nInfo.Timestamp)
 	args = append(args, nInfo.Timestamp)
+	// client info
 	args = append(args, clientDetails.RawClientName)
 	args = append(args, clientDetails.ClientName)
 	args = append(args, clientDetails.ClientVersion)
@@ -86,7 +97,14 @@ func (d *PostgresDBService) upsertNodeInfo(nInfo models.NodeInfo) (query string,
 	args = append(args, clientDetails.ClientLanguage)
 	args = append(args, capabilities)
 	args = append(args, nInfo.SoftwareInfo)
-	args = append(args, false) // we identified the peer (un-deprecate them)
+	// node chain status
+	args = append(args, hex.EncodeToString([]byte(nInfo.ForkID.Hash[:])))
+	args = append(args, nInfo.ProtocolVersion)
+	args = append(args, hex.EncodeToString(nInfo.HeadHash.Bytes()))
+	args = append(args, nInfo.NetworkID)
+	args = append(args, nInfo.TotalDifficulty)
+	// control
+	args = append(args, !sameNetwork) // we identified the peer (un-deprecate it if the are in the same network)
 
 	return query, args
 }
@@ -156,7 +174,7 @@ func (d *PostgresDBService) GetNonDeprecatedNodes() ([]models.HostInfo, error) {
 }
 
 // PersistNodeInfo is the main method to persist the node info into the DB
-func (d *PostgresDBService) PersistNodeInfo(attempt models.ConnectionAttempt, nInfo models.NodeInfo) {
+func (d *PostgresDBService) PersistNodeInfo(attempt models.ConnectionAttempt, nInfo models.NodeInfo, sameNetwork bool) {
 	// persist the attempt
 	p := NewPersistable()
 	p.query, p.values = d.insertConnectionAttempt(attempt)
@@ -165,7 +183,7 @@ func (d *PostgresDBService) PersistNodeInfo(attempt models.ConnectionAttempt, nI
 	// check if the connection was successfull to record the connection
 	if attempt.Status == models.SuccessfulConnection {
 		p := NewPersistable()
-		p.query, p.values = d.upsertNodeInfo(nInfo)
+		p.query, p.values = d.upsertNodeInfo(nInfo, sameNetwork)
 		d.writeChan <- p
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
 
 services:
   db:
-    image: postgres:latest
+    image: postgres:16.0-alpine
     environment:
       - POSTGRES_USER=${DB_USER}
       - POSTGRES_PASSWORD=${DB_PASSWORD}
@@ -24,7 +24,7 @@ services:
       timeout: 3s
       retries: 3
 
-  el-crawler:
+  ragno:
     image: "ragno:latest"
     build:
       context: .


### PR DESCRIPTION
# Motivation
We currently have a huge list of nodes/enrs from discovery4; however, we still need to find out to which network they belong (let's remember that Ethereum testnets and other projects use discv4 for peer discovery reasons).
Thus, our side has a big motivation to distinguish the nodes per network. 
 
# Description
This PR addresses a few things:
- not filtering the nodes by network means more peers to connect from the crawler's perspective. Therefore, filtering the nodes per network will allow us to reduce the overhead of the crawler
- we will be able to estimate the size of Ethereum's network (EL) 

# Tasks
- [x] Add network and other chain status-related details to the peer-handshake/peer-dial-method
- [x] Upgrade the database to support this new metadata
- [x] Adjust the deprecation system to ignore nodes that are not from our same network
- [x] Use newer chain info from remote nodes to update our chain status    

# Proof of Success 
leaving it over a larger period of time, but we have promising results from local tests:
![image](https://github.com/cortze/ragno/assets/45786396/701b6145-bed9-41df-b0f7-1727b16c0449)
